### PR TITLE
fix: arrumado bug do recurso não estar sendo deletado através do deleteById

### DIFF
--- a/src/main/java/com/ifba/dev/todolist/repositories/implem/TodoRepositoryImpl.java
+++ b/src/main/java/com/ifba/dev/todolist/repositories/implem/TodoRepositoryImpl.java
@@ -8,6 +8,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
+import javax.transaction.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,7 @@ public class TodoRepositoryImpl {
 
     public void deleteById(Long id){
         Query query = entityManager.createQuery(("Delete FROM Todo WHERE id = " + id));
+        query.executeUpdate();
     }
 
     public void updateTodo(Long id, Todo todo){

--- a/src/main/java/com/ifba/dev/todolist/repositories/interfaces/TodoRepository.java
+++ b/src/main/java/com/ifba/dev/todolist/repositories/interfaces/TodoRepository.java
@@ -17,6 +17,7 @@ public interface TodoRepository extends JpaRepository<Todo,Long> {
 
     public List<Todo> find(Long id, String name, String descricao, TodoStatus todoStatus);
 
+    @Transactional
     public void deleteById(Long id);
 
     @Transactional


### PR DESCRIPTION
* Arrumado bug do recurso não estar sendo deletado no metodo deleteById *

- Inserida anotacao @Transactional no metodo deleteById da interface TodoRepository
- Inserido uma nova linha chamando o metodo executeUpdate no metodo deleteById na classe TodoRepositoryImpl
